### PR TITLE
qol Makefile and .gitignore adjustments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,19 @@
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Test binary, built with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+# IDEs
+.idea/*
+
 # ignore code generated for tests
 examples/*/*/service/service
 examples/**/client.go

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,9 @@
 SHELL = /bin/bash
 
+mkfile_dir := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))
+
 build:	
-	go install github.com/googleapis/gnostic-go-generator
+	go install $(mkfile_dir)
 	rm -f $(GOPATH)/bin/gnostic-go-client $(GOPATH)/bin/gnostic-go-server
 	ln -s $(GOPATH)/bin/gnostic-go-generator $(GOPATH)/bin/gnostic-go-client
 	ln -s $(GOPATH)/bin/gnostic-go-generator $(GOPATH)/bin/gnostic-go-server

--- a/examples/v2.0/bookstore/Makefile
+++ b/examples/v2.0/bookstore/Makefile
@@ -1,9 +1,8 @@
+mkfile_dir := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))
+
 build:	
 	go install github.com/googleapis/gnostic
-	go install github.com/googleapis/gnostic-go-generator
-	rm -f $(GOPATH)/bin/gnostic-go-client $(GOPATH)/bin/gnostic-go-server
-	ln -s $(GOPATH)/bin/gnostic-go-generator $(GOPATH)/bin/gnostic-go-client
-	ln -s $(GOPATH)/bin/gnostic-go-generator $(GOPATH)/bin/gnostic-go-server
+	make -C $(mkfile_dir)/../../../
 
 all:	build
 	gnostic bookstore.json --go-generator-out=bookstore
@@ -16,4 +15,3 @@ test:	all
 	cd service; go get .; go build; ./service &
 	go test
 	killall service
-

--- a/examples/v2.0/sample/Makefile
+++ b/examples/v2.0/sample/Makefile
@@ -1,9 +1,8 @@
+mkfile_dir := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))
+
 build:	
 	go install github.com/googleapis/gnostic
-	go install github.com/googleapis/gnostic-go-generator
-	rm -f $(GOPATH)/bin/gnostic-go-client $(GOPATH)/bin/gnostic-go-server
-	ln -s $(GOPATH)/bin/gnostic-go-generator $(GOPATH)/bin/gnostic-go-client
-	ln -s $(GOPATH)/bin/gnostic-go-generator $(GOPATH)/bin/gnostic-go-server
+	make -C $(mkfile_dir)/../../../
 
 all:	build
 	gnostic sample.yaml --go-generator-out=sample
@@ -16,4 +15,3 @@ test:	all
 	cd service; go get .; go build; ./service &
 	go test
 	killall service
-

--- a/examples/v3.0/bookstore/Makefile
+++ b/examples/v3.0/bookstore/Makefile
@@ -1,9 +1,8 @@
+mkfile_dir := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))
+
 build:	
 	go install github.com/googleapis/gnostic
-	go install github.com/googleapis/gnostic-go-generator
-	rm -f $(GOPATH)/bin/gnostic-go-client $(GOPATH)/bin/gnostic-go-server
-	ln -s $(GOPATH)/bin/gnostic-go-generator $(GOPATH)/bin/gnostic-go-client
-	ln -s $(GOPATH)/bin/gnostic-go-generator $(GOPATH)/bin/gnostic-go-server
+	make -C $(mkfile_dir)/../../../
 
 all:	build
 	gnostic bookstore.json --go-generator-out=bookstore
@@ -16,4 +15,3 @@ test:	all
 	cd service; go get .; go build; ./service &
 	go test
 	killall service
-


### PR DESCRIPTION
The makefiles (./Makefile & ./examples/**/Makefile) were all using 'go install github.com/googleapis/gnostic-go-generator', which (unless I'm mistaken) wouldn't test local changes unless you're working in $GOPATH/src/github.com/googleapis/gnostic-go-generator, so I tweaked the Makefiles to use relative directories instead.

Also added standard go .gitignore stuff from https://github.com/github/gitignore/blob/master/Go.gitignore, and added ".idea/*" (I usually use goland).