### PR TITLE
handle any type

### DIFF
--- a/render_types.go
+++ b/render_types.go
@@ -29,15 +29,17 @@ func (renderer *Renderer) RenderTypes() ([]byte, error) {
 		if modelType.Kind == surface.TypeKind_STRUCT {
 			f.WriteLine(`type ` + modelType.TypeName + ` struct {`)
 			for _, field := range modelType.Fields {
-				prefix := ""
+				typ := field.NativeType
 				if field.Kind == surface.FieldKind_REFERENCE {
-					prefix = "*"
+					typ = "*" + typ
 				} else if field.Kind == surface.FieldKind_ARRAY {
-					prefix = "[]"
+					typ = "[]" + typ
 				} else if field.Kind == surface.FieldKind_MAP {
-					prefix = "map[string]"
+					typ = "map[string]" + typ
+				} else if field.Kind == surface.FieldKind_ANY {
+					typ = "interface{}"
 				}
-				f.WriteLine(field.FieldName + ` ` + prefix + field.NativeType + jsonTag(field))
+				f.WriteLine(field.FieldName + ` ` + typ + jsonTag(field))
 			}
 			f.WriteLine(`}`)
 		} else if modelType.Kind == surface.TypeKind_OBJECT {


### PR DESCRIPTION
Generate the `any` type as an `interface{}`.

Following the Go Discover-based client library generator and what it did with [bigquery](https://github.com/googleapis/google-api-go-client/blob/master/bigquery/v2/bigquery-gen.go#L4823).

Fixes #7 

cc @glickbot please take a look.