### PR TITLE
Adjust gnostic-go-generator to new surface model

### DIFF
--- a/examples/v2.0/bookstore/bookstore_test.go
+++ b/examples/v2.0/bookstore/bookstore_test.go
@@ -47,7 +47,7 @@ func TestBookstore(t *testing.T) {
 			t.Log("list shelves failed")
 			t.Fail()
 		}
-		if (response == nil) || (response.OK == nil) || (response.OK.Shelves != nil) {
+		if (response == nil) || (response.OK == nil) || (len(response.OK.Shelves) != 0) {
 			t.Log(fmt.Sprintf("list shelves failed %+v", response.OK))
 			t.Log(fmt.Sprintf("list shelves failed len=%d", len(response.OK.Shelves)))
 			t.Fail()

--- a/examples/v2.0/bookstore/service/service.go
+++ b/examples/v2.0/bookstore/service/service.go
@@ -68,8 +68,8 @@ func (service *Service) CreateShelf(parameters *bookstore.CreateShelfParameters,
 	service.LastShelfID++
 	sid := service.LastShelfID
 	shelf.Name = fmt.Sprintf("shelves/%d", sid)
-	service.Shelves[sid] = &shelf
-	(*responses).OK = &shelf
+	service.Shelves[sid] = shelf
+	(*responses).OK = shelf
 	return err
 }
 
@@ -144,8 +144,8 @@ func (service *Service) CreateBook(parameters *bookstore.CreateBookParameters, r
 	if service.Books[parameters.Shelf] == nil {
 		service.Books[parameters.Shelf] = make(map[int64]*bookstore.Book)
 	}
-	service.Books[parameters.Shelf][bid] = &book
-	(*responses).OK = &book
+	service.Books[parameters.Shelf][bid] = book
+	(*responses).OK = book
 	return err
 }
 

--- a/examples/v2.0/sample/service/service.go
+++ b/examples/v2.0/sample/service/service.go
@@ -30,9 +30,12 @@ func NewService() *Service {
 }
 
 func (service *Service) GetSample(parameters *sample.GetSampleParameters, responses *sample.GetSampleResponses) (err error) {
+	randomThing := sample.Thing{}
+	randomThing["thing"] = 123
+
 	(*responses).OK = &sample.Sample{
 		Id:    parameters.Id,
-		Thing: map[string]interface{}{"thing": 123},
+		Thing: &randomThing,
 		Count: int32(len(parameters.Id))}
 	return err
 }

--- a/examples/v3.0/bookstore/bookstore_test.go
+++ b/examples/v3.0/bookstore/bookstore_test.go
@@ -47,9 +47,9 @@ func TestBookstore(t *testing.T) {
 			t.Log("list shelves failed")
 			t.Fail()
 		}
-		if (response == nil) || (response.OK == nil) || (response.OK.Shelves != nil) {
+		if (response == nil) || (response.OK == nil) || (len(response.OK.ApplicationJson.Shelves) != 0) {
 			t.Log(fmt.Sprintf("list shelves failed %+v", response.OK))
-			t.Log(fmt.Sprintf("list shelves failed len=%d", len(response.OK.Shelves)))
+			t.Log(fmt.Sprintf("list shelves failed len=%d", len(response.OK.ApplicationJson.Shelves)))
 			t.Fail()
 		}
 	}
@@ -71,30 +71,36 @@ func TestBookstore(t *testing.T) {
 	}
 	// add a shelf
 	{
-		var shelf bookstore.Shelf
-		shelf.Theme = "mysteries"
-		response, err := b.CreateShelf(shelf)
+		var reqBody = bookstore.CreateShelfRequestBody{
+			ApplicationJson: &bookstore.Shelf{
+				Theme: "mysteries",
+			},
+		}
+		response, err := b.CreateShelf(reqBody)
 		if err != nil {
 			t.Log("create shelf mysteries failed")
 			t.Fail()
 		}
-		if (response.OK.Name != "shelves/1") ||
-			(response.OK.Theme != "mysteries") {
+		if (response.OK.ApplicationJson.Name != "shelves/1") ||
+			(response.OK.ApplicationJson.Theme != "mysteries") {
 			t.Log("create shelf mysteries failed")
 			t.Fail()
 		}
 	}
 	// add another shelf
 	{
-		var shelf bookstore.Shelf
-		shelf.Theme = "comedies"
-		response, err := b.CreateShelf(shelf)
+		var reqBody = bookstore.CreateShelfRequestBody{
+			ApplicationJson: &bookstore.Shelf{
+				Theme: "comedies",
+			},
+		}
+		response, err := b.CreateShelf(reqBody)
 		if err != nil {
 			t.Log("create shelf comedies failed")
 			t.Fail()
 		}
-		if (response.OK.Name != "shelves/2") ||
-			(response.OK.Theme != "comedies") {
+		if (response.OK.ApplicationJson.Name != "shelves/2") ||
+			(response.OK.ApplicationJson.Theme != "comedies") {
 			t.Log("create shelf comedies failed")
 			t.Fail()
 		}
@@ -106,8 +112,8 @@ func TestBookstore(t *testing.T) {
 			t.Log("get shelf mysteries failed")
 			t.Fail()
 		}
-		if (response.OK.Name != "shelves/1") ||
-			(response.OK.Theme != "mysteries") {
+		if (response.OK.ApplicationJson.Name != "shelves/1") ||
+			(response.OK.ApplicationJson.Theme != "mysteries") {
 			t.Log("get shelf mysteries failed")
 			t.Fail()
 		}
@@ -119,7 +125,7 @@ func TestBookstore(t *testing.T) {
 			t.Log("list shelves failed")
 			t.Fail()
 		}
-		if len(response.OK.Shelves) != 2 {
+		if len(response.OK.ApplicationJson.Shelves) != 2 {
 			t.Log("list shelves failed")
 			t.Fail()
 		}
@@ -139,7 +145,7 @@ func TestBookstore(t *testing.T) {
 			t.Log("list shelves failed")
 			t.Fail()
 		}
-		if len(response.OK.Shelves) != 1 {
+		if len(response.OK.ApplicationJson.Shelves) != 1 {
 			t.Log("list shelves failed")
 			t.Fail()
 		}
@@ -151,17 +157,20 @@ func TestBookstore(t *testing.T) {
 			t.Log("list books failed")
 			t.Fail()
 		}
-		if len(response.OK.Books) != 0 {
+		if len(response.OK.ApplicationJson.Books) != 0 {
 			t.Log("list books failed")
 			t.Fail()
 		}
 	}
 	// create a book
 	{
-		var book bookstore.Book
-		book.Author = "Agatha Christie"
-		book.Title = "And Then There Were None"
-		_, err := b.CreateBook(1, book)
+		var reqBody = bookstore.CreateBookRequestBody{
+			ApplicationJson: &bookstore.Book{
+				Author: "Agatha Christie",
+				Title:  "And Then There Were None",
+			},
+		}
+		_, err := b.CreateBook(1, reqBody)
 		if err != nil {
 			t.Log("create book failed")
 			t.Fail()
@@ -169,10 +178,13 @@ func TestBookstore(t *testing.T) {
 	}
 	// create another book
 	{
-		var book bookstore.Book
-		book.Author = "Agatha Christie"
-		book.Title = "Murder on the Orient Express"
-		_, err := b.CreateBook(1, book)
+		var reqBody = bookstore.CreateBookRequestBody{
+			ApplicationJson: &bookstore.Book{
+				Author: "Agatha Christie",
+				Title:  "Murder on the Orient Express",
+			},
+		}
+		_, err := b.CreateBook(1, reqBody)
 		if err != nil {
 			t.Log("create book failed")
 			t.Fail()
@@ -193,7 +205,7 @@ func TestBookstore(t *testing.T) {
 			t.Log("list books failed")
 			t.Fail()
 		}
-		if len(response.OK.Books) != 2 {
+		if len(response.OK.ApplicationJson.Books) != 2 {
 			t.Log("list books failed")
 			t.Fail()
 		}
@@ -213,7 +225,7 @@ func TestBookstore(t *testing.T) {
 			t.Log("list books failed")
 			t.Fail()
 		}
-		if len(response.OK.Books) != 1 {
+		if len(response.OK.ApplicationJson.Books) != 1 {
 			t.Log("list books failed")
 			t.Fail()
 		}

--- a/examples/v3.0/bookstore/service/service.go
+++ b/examples/v3.0/bookstore/service/service.go
@@ -91,7 +91,7 @@ func (service *Service) GetShelf(parameters *bookstore.GetShelfParameters, respo
 	shelf, err := service.getShelf(parameters.Shelf)
 	if err != nil {
 		defaultResponse := &bookstore.GetShelfDefault{
-			ApplicationJson: &bookstore.Error{Code: int32(http.StatusNotFound), Message: "fck2"},
+			ApplicationJson: &bookstore.Error{Code: int32(http.StatusNotFound), Message: err.Error()},
 		}
 		(*responses).Default = defaultResponse
 		return nil

--- a/examples/v3.0/bookstore/service/service.go
+++ b/examples/v3.0/bookstore/service/service.go
@@ -12,6 +12,7 @@
  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  See the License for the specific language governing permissions and
  limitations under the License.
+
 */
 
 package main

--- a/render_server.go
+++ b/render_server.go
@@ -16,7 +16,6 @@ package main
 
 import (
 	"fmt"
-
 	surface "github.com/googleapis/gnostic/surface"
 )
 
@@ -130,6 +129,10 @@ func (renderer *Renderer) RenderServer() ([]byte, error) {
 			if responsesType.HasFieldWithName("Default") {
 				f.WriteLine(`if responses.Default != nil {`)
 				f.WriteLine(`  // write the error response`)
+				contentType := responsesType.FieldWithName("Default").ServiceType(renderer.Model).FieldWithName("Application/Json")
+				if contentType != nil && contentType.ServiceType(renderer.Model).FieldWithName("Code") != nil {
+					f.WriteLine(`  w.WriteHeader(int(responses.Default.ApplicationJson.Code))`)
+				}
 				if responsesType.FieldWithName("Default").ServiceType(renderer.Model).FieldWithName("Code") != nil {
 					f.WriteLine(`  w.WriteHeader(int(responses.Default.Code))`)
 				}

--- a/render_types.go
+++ b/render_types.go
@@ -16,6 +16,7 @@ package main
 
 import (
 	surface "github.com/googleapis/gnostic/surface"
+	"strings"
 )
 
 func (renderer *Renderer) RenderTypes() ([]byte, error) {
@@ -35,11 +36,12 @@ func (renderer *Renderer) RenderTypes() ([]byte, error) {
 				} else if field.Kind == surface.FieldKind_ARRAY {
 					typ = "[]" + typ
 				} else if field.Kind == surface.FieldKind_MAP {
-					typ = "map[string]" + typ
+					typ = field.Type
 				} else if field.Kind == surface.FieldKind_ANY {
 					typ = "interface{}"
 				}
-				f.WriteLine(field.FieldName + ` ` + typ + jsonTag(field))
+				cleanedName := strings.Replace(field.FieldName, "/", "", -1)
+				f.WriteLine(cleanedName + ` ` + typ + jsonTag(field))
 			}
 			f.WriteLine(`}`)
 		} else if modelType.Kind == surface.TypeKind_OBJECT {


### PR DESCRIPTION
Adjusts this plugin to the new surface model implementation.

[Line 39](https://github.com/googleapis/gnostic-go-generator/pull/14/commits/cd1f711ea0716283c52d36344c1ae36e0b153c11#diff-a8d5410cf798e0d31f7a86c891b19fdaR39): We get the entire type from the surface model ([see](https://github.com/googleapis/gnostic/blob/ee703ec34d5af83cfff23e805a7b0c65c8222360/surface/model_openapiv3.go#L382))

[Line 43](https://github.com/googleapis/gnostic-go-generator/pull/14/commits/cd1f711ea0716283c52d36344c1ae36e0b153c11#diff-a8d5410cf798e0d31f7a86c891b19fdaR43): The new surface model is a bit more verbose in terms of generating Types. For example, it also generates field names for 'application/json' (and others). This line replaces the '/'.

[Line 132](https://github.com/googleapis/gnostic-go-generator/pull/14/files#diff-7d6fb97e69e6ebf775da30a303d8bf8eR132): As above. The surface model for v3 specifications is a bit more verbose.

After [PR145](https://github.com/googleapis/gnostic/pull/145) is merged CI should work here as well.