### PR TITLE
Expose mux router on initialize

### DIFF
--- a/render_server.go
+++ b/render_server.go
@@ -146,13 +146,14 @@ func (renderer *Renderer) RenderServer() ([]byte, error) {
 		f.WriteLine(``)
 	}
 	f.WriteLine(`// Initialize the API service.`)
-	f.WriteLine(`func Initialize(p Provider) {`)
+	f.WriteLine(`func Initialize(p Provider) *mux.Router {`)
 	f.WriteLine(`  provider = p`)
 	f.WriteLine(`  var router = mux.NewRouter()`)
 	for _, method := range renderer.Model.Methods {
 		f.WriteLine(`router.HandleFunc("` + method.Path + `", ` + method.HandlerName + `).Methods("` + method.Method + `")`)
 	}
 	f.WriteLine(`  http.Handle("/", router)`)
+	f.WriteLine(`  return router`)
 	f.WriteLine(`}`)
 	f.WriteLine(``)
 	f.WriteLine(`// Provide the API service over HTTP.`)


### PR DESCRIPTION
### Description
Exposing mux router so that wen can extend middleware in server

### Sample usage
```
middleware := func(h http.Handler) http.Handler {
	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
		log.Println("middleware", r.URL)
		h.ServeHTTP(w, r)
	})
}
r := bookstore.Initialize(NewService())
r.Use(middleware)
```